### PR TITLE
Contract review

### DIFF
--- a/src/RLN.sol
+++ b/src/RLN.sol
@@ -5,6 +5,10 @@ import {IPoseidonHasher} from "./PoseidonHasher.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+// error for "RLN, register: set is full"
+error SetIsFull(uint256 pubkeyIndex, uint256 setSize);
+
+
 contract RLN {
     // ERC20 staking support
     using SafeERC20 for IERC20;
@@ -52,7 +56,9 @@ contract RLN {
     }
 
     function register(uint256 pubkey) external {
-        require(pubkeyIndex < SET_SIZE, "RLN, register: set is full");
+        if (pubkeyIndex >= SET_SIZE) {
+            revert SetIsFull(pubkeyIndex, SET_SIZE);
+        }
 
         token.safeTransferFrom(msg.sender, address(this), MEMBERSHIP_DEPOSIT);
         _register(pubkey);

--- a/src/RLN.sol
+++ b/src/RLN.sol
@@ -18,6 +18,7 @@ contract RLN {
 
     // Fee percentage
     uint256 public constant FEE_PERCENTAGE = 5;
+    uint256 public constant FEE_PERCENTAGE_DENOMINATOR = 100;
     // Fee amount
     uint256 public immutable FEE;
 
@@ -43,7 +44,8 @@ contract RLN {
         SET_SIZE = 1 << depth;
 
         FEE_RECEIVER = feeReceiver;
-        FEE = FEE_PERCENTAGE * MEMBERSHIP_DEPOSIT / 100;
+        require(FEE_PERCENTAGE <= FEE_PERCENTAGE_DENOMINATOR, "RLN, constructor: invalid fee percentage");
+        FEE = FEE_PERCENTAGE * MEMBERSHIP_DEPOSIT / FEE_PERCENTAGE_DENOMINATOR;
 
         poseidonHasher = IPoseidonHasher(_poseidonHasher);
         token = IERC20(_token);

--- a/src/RLN.sol
+++ b/src/RLN.sol
@@ -78,10 +78,11 @@ contract RLN {
 
     function withdraw(uint256 secret, address receiver) external {
         uint256 pubkey = hash(secret);
-        require(members[pubkey] != address(0), "RLN, _withdraw: member doesn't exist");
+        address _memberAddress = members[pubkey];
+        require(_memberAddress != address(0), "RLN, _withdraw: member doesn't exist");
         require(receiver != address(0), "RLN, _withdraw: empty receiver address");
 
-        if (members[pubkey] == receiver) {
+        if (_memberAddress == receiver) {
             token.safeTransfer(receiver, MEMBERSHIP_DEPOSIT);
             emit MemberWithdrawn(pubkey);
         } else {


### PR DESCRIPTION
The contract is already well-written and should work correctly. Below are some nitpicks:
1. Check `FEE_PERCENTAGE` in constructor: https://github.com/mhchia/rln-contract/commit/5e9029a6a5b19de18af803fe67ce62d5df053576.
2. Cache read storage to avoid reading it twice: https://github.com/mhchia/rln-contract/commit/7e617bd8151565bcc30b50400024354551f0c68d
3. Custom error to save deployment gas: https://github.com/mhchia/rln-contract/commit/57ad159955832b8f49ebfbeb114d5cbd4c9f2fa3

I also think it's still worthwhile to hide `secret` in `withdraw` somehow. Right now, it's likely for a `withdraw` to be front-run by a normal MEV bot even if it does not know RLN at all. Hiding the secret with a commit & reveal scheme, ZKP proof with `secret` as private input, ...etc. can at least require the front-runner also help to participate RLN network (because they still need the leaked partitioned secret to recover the entire secret)